### PR TITLE
Mehrheit in MV auf 50%+1 ändern

### DIFF
--- a/satzung.tex
+++ b/satzung.tex
@@ -180,8 +180,9 @@ Vereinsmitglieder mit je einer Stimme an.
 \item Das Stimmrecht kann nur persönlich oder für ein Mitglied unter Vorlage 
 einer schriftlichen Vollmacht ausgeübt werden.
 
-\item Bei Abstimmungen entscheidet die einfache Mehrheit der abgegebenen 
-Stimmen.
+\item Bei Abstimmungen entscheidet die qualifizierte Mehrheit der abgegebenen 
+Stimmen: Mindestens die Hälfte plus eine Stimme muss für den Abstimmungsgegenstand
+abgegeben sein.
 
 \item Abstimmungen erfolgen öffentlich, sofern nicht von mindestens einem 
 Abstimmungsberechtigten eine geheime Abstimmung gewünscht wird.


### PR DESCRIPTION
Mit einfachen Mehrheiten kommt immer das Problem, dass eine Abstimmung mit vielen Optionen eine große Mehrheit unzufrieden machen kann: 100% Stimmen / 5 Vorschläge, Annahme: ein Vorschlag bekommt 21% => 79% sind damit vielleicht eigentlich nicht einverstanden. Das ließe sich durch qualifizierte Mehrheit von 50%+1 verhindern.