### PR TITLE
Bedingung der Aktivitat für ordentliche Mitglieder hervorheben

### DIFF
--- a/satzung.tex
+++ b/satzung.tex
@@ -67,7 +67,7 @@ Fördermitglieder, die den oben genannten Vereinszweck ideell oder materiell
 unterstützen.
 
 \item Ordentliche Mitglieder können jede natürliche Person sein,  die im Verein oder einem von
-ihm geförderten Projekt aktiv mitarbeiten möchten. Fördermitglieder können jede natürliche
+ihm geförderten Projekt ausdrücklich aktiv mitarbeiten möchten. Fördermitglieder können jede natürliche
 als auch juristische Person werden, die die Ziele und den
 Zweck des Vereins fördern und unterstützen möchten.
 


### PR DESCRIPTION
Die Idee war die ordentliche Mitgliederbasis übersichtlich zu halten, indem sie auf tatsächlich aktive Mitglieder beschränkt ist. Dies ist der Versuch das hervorzuheben.