### PR TITLE
Möglichkeit einer Geschäftsordnung fur den Vorstand

### DIFF
--- a/satzung.tex
+++ b/satzung.tex
@@ -267,6 +267,8 @@ Vorstand.
 durch die nächste Mitgliederversammlung bedarf.
 
 \item Der Vorstand arbeitet ehrenamtlich. % §27 (3) BGB
+
+\item Der Vorstands kann sich eine Geschäftsordnung geben.
 \end{enumerate}
 
 \section{Auflösung des Vereins}


### PR DESCRIPTION
Es kann hilfreich sein, wenn sich der Vorstand eine Geschäftsordnung geben kann, bspw. auch um bei Übergaben erstmal eine gewisse Konsistenz sicherzustellen.