### PR TITLE
Einladung und Abstimmung im Vorstand explizit beschreiben

### DIFF
--- a/satzung.tex
+++ b/satzung.tex
@@ -242,6 +242,13 @@ entscheidet über diese und setzt sie satzungsgemäß um.
 nicht eines Beschlusses der Mitgliederversammlung bedürfen. Er führt die 
 Beschlüsse der Mitgliederversammlung aus.
 
+\item Zur Vorstandssitzung wird mit einer Frist von zwei Wochen, ohne
+Angabe der Tagesordnung und Beschlussgegenstände eingeladen.
+
+\item Abstimmungen zu Beschlüssen des Vorstands sind angenommen, wenn
+die Hälfte aller Vorstandsmitglieder plus ein Vorstandsmitglied dem
+Beschluss zustimmt.
+
 \item Beschlüsse des Vorstands können auch schriftlich oder fernmündlich 
 gefasst werden. Schriftlich oder fernmündlich gefasste Vorstandsbeschlüsse 
 sind schriftlich niederzulegen und vom Vorstand zu unterzeichnen.


### PR DESCRIPTION
Expliziter auszuschreiben wie der Vorstand agieren kann / Beschlüsse fasst, ist hilfreich, da ansonsten ggf. Unsicherheiten bestehen. Bsp.: Es kann sein, dass dann implizit die Vorgaben der MV für Vorstandssitzungen gelten "könnten". Das wäre bswp. für Vorstandssitzungen i.d.R. zu starr.