### PR TITLE
Eindeutiger machen

### DIFF
--- a/satzung.tex
+++ b/satzung.tex
@@ -101,7 +101,7 @@ verfügbar gemacht.
 \item Eine Ehrenmitgliedschaft kann im Einverständnis zwischen dem Mitglied 
 und dem Vorstand in eine ordentliche Mitgliedschaft umgewandelt werden.
 
-\item Zum Erwerb der ordentlichen Mitgliedschaft oder Umwandlung der 
+\item Zum Erwerb der ordentlichen Mitgliedschaft oder Fördermitgliedschaft oder Umwandlung der 
 Ehrenmitgliedschaft in eine ordentliche Mitgliedschaft ist bei 
 Minderjährigen die Zustimmung des gesetzlichen Vertreters erforderlich.
 \end{enumerate}

--- a/satzung.tex
+++ b/satzung.tex
@@ -186,7 +186,7 @@ Stimmen.
 \item Abstimmungen erfolgen öffentlich, sofern nicht von mindestens einem 
 Abstimmungsberechtigten eine geheime Abstimmung gewünscht wird.
 
-\item Die Leitung der Versammlung hat ein Mitglied des Vorstands oder ein von 
+\item Die Leitung der Versammlung hat ein Mitglied des Vorstands. In deren Abwesenheit ein von 
 der Mitgliederversammlung bestimmte(r) Versammlungsleiter(in).
 
 \item Zu Beginn der Mitgliederversammlung ist ein Schriftführer zu wählen.


### PR DESCRIPTION
Zwei kleine Änderungen, um den Vorgang eindeutiger zu machen:
1. Auch Fördermitgliedschaften bei Minderjährigen explizit behandeln, nicht nur ordentliche Mitgliedschaften.
2. Regelung zur Leitung der MV eindeutig machen, um Unsicherheit zu vermeiden.